### PR TITLE
add-finalizer-to-awscluster

### DIFF
--- a/controllers/awsmachinepool_controller.go
+++ b/controllers/awsmachinepool_controller.go
@@ -104,7 +104,7 @@ func (r *AWSMachinePoolReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 		{
 			awsCluster, err := key.GetAWSClusterByName(ctx, r.Client, clusterName)
 			if err != nil {
-				logger.Error(err, "failed get awsCluster")
+				logger.Error(err, "failed to get awsCluster")
 				return ctrl.Result{}, err
 			}
 			controllerutil.RemoveFinalizer(awsCluster, key.FinalizerName(iam.NodesRole))

--- a/controllers/awsmachinepool_controller.go
+++ b/controllers/awsmachinepool_controller.go
@@ -110,7 +110,7 @@ func (r *AWSMachinePoolReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 			controllerutil.RemoveFinalizer(awsCluster, key.FinalizerName(iam.NodesRole))
 			err = r.Update(ctx, awsCluster)
 			if err != nil {
-				logger.Error(err, "failed to add finalizer on AWSCluster")
+				logger.Error(err, "failed to remove finalizer on AWSCluster")
 				return ctrl.Result{}, err
 			}
 		}

--- a/controllers/awsmachinepool_controller.go
+++ b/controllers/awsmachinepool_controller.go
@@ -140,7 +140,7 @@ func (r *AWSMachinePoolReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 		{
 			awsCluster, err := key.GetAWSClusterByName(ctx, r.Client, clusterName)
 			if err != nil {
-				logger.Error(err, "failed get awsCluster")
+				logger.Error(err, "failed to get awsCluster")
 				return ctrl.Result{}, err
 			}
 			controllerutil.AddFinalizer(awsCluster, key.FinalizerName(iam.NodesRole))

--- a/controllers/awsmachinepool_controller.go
+++ b/controllers/awsmachinepool_controller.go
@@ -107,7 +107,7 @@ func (r *AWSMachinePoolReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 				logger.Error(err, "failed get awsCluster")
 				return ctrl.Result{}, err
 			}
-			controllerutil.RemoveFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole))
+			controllerutil.RemoveFinalizer(awsCluster, key.FinalizerName(iam.NodesRole))
 			err = r.Update(ctx, awsCluster)
 			if err != nil {
 				logger.Error(err, "failed to add finalizer on AWSCluster")
@@ -143,7 +143,7 @@ func (r *AWSMachinePoolReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 				logger.Error(err, "failed get awsCluster")
 				return ctrl.Result{}, err
 			}
-			controllerutil.AddFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole))
+			controllerutil.AddFinalizer(awsCluster, key.FinalizerName(iam.NodesRole))
 			err = r.Update(ctx, awsCluster)
 			if err != nil {
 				logger.Error(err, "failed to add finalizer on AWSCluster")

--- a/controllers/awsmachinetemplate_controller.go
+++ b/controllers/awsmachinetemplate_controller.go
@@ -122,13 +122,13 @@ func (r *AWSMachineTemplateReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 		{
 			awsCluster, err := key.GetAWSClusterByName(ctx, r.Client, clusterName)
 			if err != nil {
-				logger.Error(err, "failed get awsCluster")
+				logger.Error(err, "failed to get awsCluster")
 				return ctrl.Result{}, err
 			}
 			controllerutil.RemoveFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole))
 			err = r.Update(ctx, awsCluster)
 			if err != nil {
-				logger.Error(err, "failed to add finalizer on AWSCluster")
+				logger.Error(err, "failed to remove finalizer on AWSCluster")
 				return ctrl.Result{}, err
 			}
 		}
@@ -170,7 +170,7 @@ func (r *AWSMachineTemplateReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 		{
 			awsCluster, err := key.GetAWSClusterByName(ctx, r.Client, clusterName)
 			if err != nil {
-				logger.Error(err, "failed get awsCluster")
+				logger.Error(err, "failed to get awsCluster")
 				return ctrl.Result{}, err
 			}
 			controllerutil.AddFinalizer(awsCluster, key.FinalizerName(iam.ControlPlaneRole))

--- a/pkg/awsclient/awsclient.go
+++ b/pkg/awsclient/awsclient.go
@@ -48,7 +48,7 @@ func New(config AWSClientConfig) (*AwsClient, error) {
 func (a *AwsClient) GetAWSClientSession(ctx context.Context) (clientaws.ConfigProvider, error) {
 	awsCluster, err := key.GetAWSClusterByName(ctx, a.ctrlClient, a.clusterName)
 	if err != nil {
-		a.log.Error(err, "failed to get AWSCLuster")
+		a.log.Error(err, "failed to get AWSCluster")
 		return nil, err
 	}
 

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -32,7 +32,7 @@ func GetAWSClusterByName(ctx context.Context, ctrlClient client.Client, clusterN
 	}
 
 	if len(awsClusterList.Items) != 1 {
-		return nil, fmt.Errorf("expected 1 AWSCLuster but found %d", len(awsClusterList.Items))
+		return nil, fmt.Errorf("expected 1 AWSCluster but found %d", len(awsClusterList.Items))
 	}
 
 	return &awsClusterList.Items[0], nil

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -2,7 +2,6 @@ package key
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	capa "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
@@ -32,7 +31,7 @@ func GetAWSClusterByName(ctx context.Context, ctrlClient client.Client, clusterN
 	}
 
 	if len(awsClusterList.Items) != 1 {
-		return nil, errors.New(fmt.Sprintf("expected 1 AWSCLuster but found %d", len(awsClusterList.Items)))
+		return nil, fmt.Errorf("expected 1 AWSCLuster but found %d", len(awsClusterList.Items))
 	}
 
 	return &awsClusterList.Items[0], nil

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -1,15 +1,39 @@
 package key
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
 	capa "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	CAPAIAMControllerFinalizer = "capa-iam-controller.finalizers.giantswarm.io"
-
 	ClusterNameLabel = "cluster.x-k8s.io/cluster-name"
 )
 
+func FinalizerName(roleName string) string {
+	return fmt.Sprintf("capa-iam-controller.finalizers.giantswarm.io/%s", roleName)
+}
+
 func GetClusterIDFromLabels(t *capa.AWSMachineTemplate) string {
 	return t.GetLabels()[ClusterNameLabel]
+}
+
+func GetAWSClusterByName(ctx context.Context, ctrlClient client.Client, clusterName string) (*capa.AWSCluster, error) {
+	awsClusterList := &capa.AWSClusterList{}
+
+	if err := ctrlClient.List(ctx,
+		awsClusterList,
+		client.MatchingLabels{ClusterNameLabel: clusterName},
+	); err != nil {
+		return nil, err
+	}
+
+	if len(awsClusterList.Items) != 1 {
+		return nil, errors.New(fmt.Sprintf("expected 1 AWSCLuster but found %d", len(awsClusterList.Items)))
+	}
+
+	return &awsClusterList.Items[0], nil
 }


### PR DESCRIPTION
 because AWSCluster is holding reference to the AWS credentials, we need to keep it until IAM roles are cleaned up, otherwise, we could end up with orphaned resources