### PR TITLE
restrict-secret-manager-permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Restrict `secretmanager` service permissions to access secrets with CAPI prefix.
+
 ## [0.1.1] - 2021-07-15
 
 - Rename Route53 and KIAM role names to match previous naming scheme.

--- a/pkg/iam/control_plane_template.go
+++ b/pkg/iam/control_plane_template.go
@@ -143,7 +143,7 @@ const controlPlanePolicyTemplate = `{
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:DeleteSecret"
             ],
-            "Resource": "*",
+            "Resource": "arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*",
             "Effect": "Allow"
         }
     ]

--- a/pkg/iam/nodes_template.go
+++ b/pkg/iam/nodes_template.go
@@ -129,6 +129,14 @@ const nodesTemplate = `{
                 "*"
             ],
             "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DeleteSecret"
+            ],
+            "Resource": "arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*",
+            "Effect": "Allow"
         }
     ]
 }`

--- a/pkg/iam/testdata/inline-role-policy-case-0-control-plane.golden
+++ b/pkg/iam/testdata/inline-role-policy-case-0-control-plane.golden
@@ -128,7 +128,7 @@
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:DeleteSecret"
             ],
-            "Resource": "*",
+            "Resource": "arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*",
             "Effect": "Allow"
         }
     ]

--- a/pkg/iam/testdata/inline-role-policy-case-1-node.golden
+++ b/pkg/iam/testdata/inline-role-policy-case-1-node.golden
@@ -127,6 +127,14 @@
                 "*"
             ],
             "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DeleteSecret"
+            ],
+            "Resource": "arn:*:secretsmanager:*:*:secret:aws.cluster.x-k8s.io/*",
+            "Effect": "Allow"
         }
     ]
 }


### PR DESCRIPTION
 - Restrict `secretmanager` service permissions to access secrets with CAPI prefix.