### PR TITLE
watch-only-capa-cp-aws-machine-templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Restrict `secretmanager` service permissions to access secrets with CAPI prefix.
+- Only watch for CRs with capi watch filter.
+- AWSMachinteTemplate controller - only watch for CRs with control plane role.
 
 ## [0.1.1] - 2021-07-15
 

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -10,7 +10,9 @@ import (
 )
 
 const (
-	ClusterNameLabel = "cluster.x-k8s.io/cluster-name"
+	ClusterNameLabel        = "cluster.x-k8s.io/cluster-name"
+	ClusterWatchFilterLabel = "cluster.x-k8s.io/watch-filter"
+	ClusterRole             = "cluster.x-k8s.io/role"
 )
 
 func FinalizerName(roleName string) string {
@@ -36,4 +38,24 @@ func GetAWSClusterByName(ctx context.Context, ctrlClient client.Client, clusterN
 	}
 
 	return &awsClusterList.Items[0], nil
+}
+
+func HasCapiWatchLabel(labels map[string]string) bool {
+	value, ok := labels[ClusterWatchFilterLabel]
+	if ok {
+		if value == "capi" {
+			return true
+		}
+	}
+	return false
+}
+
+func IsControlPlaneAWSMachineTemplate(labels map[string]string) bool {
+	value, ok := labels[ClusterRole]
+	if ok {
+		if value == "control-plane" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
ignore CRs that don't have CAPI watch=filter

For AWSMachineTemplate we only watch CRs that have role label with value control-plane  to avoid creating IAM roles for additional machines   like bastion